### PR TITLE
Allow msg.payload.image to be a Buffer

### DIFF
--- a/mastodon/sendMessage.html
+++ b/mastodon/sendMessage.html
@@ -41,6 +41,8 @@
 <script type="text/x-red" data-help-name="sendMessage">
     <h1>Posts to Mastodon</h2>
     <p>put the text of the post in msg.payload.text, and put the media in msg.payload.image if you have one</p>
+    <p>msg.payload.image can be a path to a local file or a buffer containing the image</p>
+    <p>msg.payload.description can also hold the image description to be used as the Alt Text</p>
 </script>
 
 <!-- Finally, the node type is registered along with all of its properties   -->

--- a/mastodon/sendMessage.js
+++ b/mastodon/sendMessage.js
@@ -56,7 +56,9 @@ module.exports = function(RED) {
         if (typeof msg.payload.image === 'string') {
           file = fs.createReadStream(msg.payload.image)
         } else if (typeof msg.payload.image === 'object' && Buffer.isBuffer(msg.payload.image)) {
+          console.log("image is buffer")
           file = new Duplex()
+          file.path = '/tmp/image'
           file.push(msg.payload.image)
           file.push(null)
         }

--- a/mastodon/sendMessage.js
+++ b/mastodon/sendMessage.js
@@ -62,10 +62,13 @@ module.exports = function(RED) {
           file.push(msg.payload.image)
           file.push(null)
         }
-        M.post('media', {
-          file: file,
-          description: msg.payload.description
-        }).then(resp => {
+        const body = {
+          file
+        }
+        if (msg.payload.description) {
+          body.description = msg.payload.description
+        }
+        M.post('media', body).then(resp => {
           id = resp.data.id;
           M.post('statuses', {
             status: msg.payload.text,

--- a/mastodon/sendMessage.js
+++ b/mastodon/sendMessage.js
@@ -63,7 +63,8 @@ module.exports = function(RED) {
           file.push(null)
         }
         M.post('media', {
-          file: file
+          file: file,
+          description: msg.payload.description
         }).then(resp => {
           id = resp.data.id;
           M.post('statuses', {


### PR DESCRIPTION
A quick PR to allow `msg.paylaod.image` to be a buffer instead of just a file path.

Should help fix #4 
