### PR TITLE
Support multiple images in sending mastodon posts

### DIFF
--- a/mastodon/sendMessage.html
+++ b/mastodon/sendMessage.html
@@ -43,6 +43,10 @@
     <p>put the text of the post in msg.payload.text, and put the media in msg.payload.image if you have one</p>
     <p>msg.payload.image can be a path to a local file or a buffer containing the image</p>
     <p>msg.payload.description can also hold the image description to be used as the Alt Text</p>
+    <h2>Multiple Images</h2>
+    <p>msg.payload.image can also be an array to upload multiple images at once</p>
+    <p>Each array item should be an object with { image: buffer/filename, description: string } to include alt text for each image</p>
+    <p>Example: msg.payload.image = [{ image: Buffer.from(...), description: "First image" }, { image: "/path/to/file.jpg", description: "Second image" }]</p>
 </script>
 
 <!-- Finally, the node type is registered along with all of its properties   -->

--- a/mastodon/sendMessage.js
+++ b/mastodon/sendMessage.js
@@ -83,7 +83,7 @@ module.exports = function(RED) {
           // Handle array of images
           const uploadPromises = msg.payload.image.map(item => {
             // Each item should be { image: buffer/filename, description: string }
-            if (typeof item === 'object' && item.image) {
+            if (item && typeof item === 'object' && !Array.isArray(item) && item.image) {
               return uploadImage(M, item.image, item.description);
             } else {
               // Fallback for simple array of buffers/filenames
@@ -121,6 +121,14 @@ module.exports = function(RED) {
           // Handle single image (existing behavior)
           var id;
           var file = createFileStream(msg.payload.image);
+          if (!file) {
+            this.status({
+              fill: "red",
+              shape: "dot",
+              text: "Error: Invalid image data"
+            });
+            return;
+          }
           const body = {
             file
           }
@@ -166,11 +174,18 @@ module.exports = function(RED) {
         if (msg.payload.sensitive) {
           body.sensitive = true
         }
-        M.post('statuses', body);
-        this.status({
-          fill: "green",
-          shape: "dot",
-          text: "sent: " + msg.payload.text
+        M.post('statuses', body).then(() => {
+          this.status({
+            fill: "green",
+            shape: "dot",
+            text: "sent: " + msg.payload.text
+          });
+        }).catch(err => {
+          this.status({
+            fill: "red",
+            shape: "dot",
+            text: "Error: " + err.message
+          });
         });
       }
     });

--- a/mastodon/sendMessage.js
+++ b/mastodon/sendMessage.js
@@ -103,7 +103,8 @@ module.exports = function(RED) {
             if (msg.payload.sensitive) {
               body.sensitive = true;
             }
-            M.post('statuses', body);
+            return M.post('statuses', body);
+          }).then(() => {
             this.status({
               fill: "green",
               shape: "dot",
@@ -139,11 +140,18 @@ module.exports = function(RED) {
             if (msg.payload.sensitive) {
               body.sensitive = true
             }
-            M.post('statuses', body);
+            return M.post('statuses', body);
+          }).then(() => {
             this.status({
               fill: "green",
               shape: "dot",
               text: "sent: " + msg.payload.text
+            });
+          }).catch(err => {
+            this.status({
+              fill: "red",
+              shape: "dot",
+              text: "Error: " + err.message
             });
           });
         }

--- a/mastodon/sendMessage.js
+++ b/mastodon/sendMessage.js
@@ -16,10 +16,10 @@
  * limitations under the License.
  **/
 
-module.exports = function(RED) {
-  var Masto = require('mastodon')
+module.exports = function (RED) {
+  var Masto = require('mastodon');
   const fs = require('fs');
-  const {Duplex} = require('stream')
+  const { Duplex } = require('stream');
 
   // Helper function to create a file stream from image data
   function createFileStream(imageData) {
@@ -45,7 +45,7 @@ module.exports = function(RED) {
     if (description) {
       body.description = description;
     }
-    return M.post('media', body).then(resp => resp.data.id);
+    return M.post('media', body).then((resp) => resp.data.id);
   }
 
   function sendMessage(n) {
@@ -58,7 +58,7 @@ module.exports = function(RED) {
     var api_url;
     var node = this;
 
-    // Get varables from the node
+    // Get variables from the node
     this.access_token = n.access_token;
     this.visibility = n.visibility;
     this.timeout_ms = n.timeout_ms;
@@ -66,12 +66,12 @@ module.exports = function(RED) {
 
     // Status icon
     this.status({
-      fill: "grey",
-      shape: "dot",
-      text: "Waiting"
+      fill: 'grey',
+      shape: 'dot',
+      text: 'Waiting',
     });
 
-    this.on("input", function(msg) {
+    this.on('input', function (msg) {
       var M = new Masto({
         access_token: this.access_token,
         timeout_ms: this.timeout_ms, // optional HTTP request timeout to apply to all requests.
@@ -81,9 +81,14 @@ module.exports = function(RED) {
         // Check if image is an array
         if (Array.isArray(msg.payload.image)) {
           // Handle array of images
-          const uploadPromises = msg.payload.image.map(item => {
+          const uploadPromises = msg.payload.image.map((item) => {
             // Each item should be { image: buffer/filename, description: string }
-            if (item && typeof item === 'object' && !Array.isArray(item) && item.image) {
+            if (
+              item &&
+              typeof item === 'object' &&
+              !Array.isArray(item) &&
+              item.image
+            ) {
               return uploadImage(M, item.image, item.description);
             } else {
               // Fallback for simple array of buffers/filenames
@@ -91,111 +96,102 @@ module.exports = function(RED) {
             }
           });
 
-          Promise.all(uploadPromises).then(media_ids => {
-            const body = {
-              status: msg.payload.text,
-              visibility: msg.payload.visibility || this.visibility,
-              media_ids: media_ids
-            };
-            if (msg.payload.contentWarning) {
-              body.spoiler_text = msg.payload.contentWarning;
-            }
-            if (msg.payload.sensitive) {
-              body.sensitive = true;
-            }
-            return M.post('statuses', body);
-          }).then(() => {
-            this.status({
-              fill: "green",
-              shape: "dot",
-              text: "sent: " + msg.payload.text
+          Promise.all(uploadPromises)
+            .then((media_ids) => {
+              const body = {
+                status: msg.payload.text,
+                visibility: msg.payload.visibility || this.visibility,
+                media_ids: media_ids,
+              };
+              if (msg.payload.contentWarning) {
+                body.spoiler_text = msg.payload.contentWarning;
+              }
+              if (msg.payload.sensitive) {
+                body.sensitive = true;
+              }
+              return M.post('statuses', body);
+            })
+            .then(() => {
+              this.status({
+                fill: 'green',
+                shape: 'dot',
+                text: 'sent: ' + msg.payload.text,
+              });
+            })
+            .catch((err) => {
+              this.status({
+                fill: 'red',
+                shape: 'dot',
+                text: 'Error: ' + err.message,
+              });
             });
-          }).catch(err => {
-            this.status({
-              fill: "red",
-              shape: "dot",
-              text: "Error: " + err.message
-            });
-          });
         } else {
           // Handle single image (existing behavior)
-          var id;
-          var file = createFileStream(msg.payload.image);
-          if (!file) {
-            this.status({
-              fill: "red",
-              shape: "dot",
-              text: "Error: Invalid image data"
+          uploadImage(M, msg.payload.image, msg.payload.description)
+            .then((id) => {
+              const body = {
+                status: msg.payload.text,
+                visibility: msg.payload.visibility || this.visibility,
+                media_ids: [id],
+              };
+              if (msg.payload.contentWarning) {
+                body.spoiler_text = msg.payload.contentWarning;
+              }
+              if (msg.payload.sensitive) {
+                body.sensitive = true;
+              }
+              return M.post('statuses', body);
+            })
+            .then(() => {
+              this.status({
+                fill: 'green',
+                shape: 'dot',
+                text: 'sent: ' + msg.payload.text,
+              });
+            })
+            .catch((err) => {
+              this.status({
+                fill: 'red',
+                shape: 'dot',
+                text: 'Error: ' + err.message,
+              });
             });
-            return;
-          }
-          const body = {
-            file
-          }
-          if (msg.payload.description) {
-            body.description = msg.payload.description
-          }
-          M.post('media', body).then(resp => {
-            id = resp.data.id;
-            const body = {
-              status: msg.payload.text,
-              visibility: msg.payload.visibility || this.visibility,
-              media_ids: [id]
-            }
-            if (msg.payload.contentWarning) {
-              body.spoiler_text = msg.payload.contentWarning
-            }
-            if (msg.payload.sensitive) {
-              body.sensitive = true
-            }
-            return M.post('statuses', body);
-          }).then(() => {
-            this.status({
-              fill: "green",
-              shape: "dot",
-              text: "sent: " + msg.payload.text
-            });
-          }).catch(err => {
-            this.status({
-              fill: "red",
-              shape: "dot",
-              text: "Error: " + err.message
-            });
-          });
         }
       } else {
         const body = {
           status: msg.payload.text,
-          visibility: msg.payload.visibility || this.visibility
-        }
+          visibility: msg.payload.visibility || this.visibility,
+        };
         if (msg.payload.contentWarning) {
-          body.spoiler_text = msg.payload.contentWarning
+          body.spoiler_text = msg.payload.contentWarning;
         }
         if (msg.payload.sensitive) {
-          body.sensitive = true
+          body.sensitive = true;
         }
-        M.post('statuses', body).then(() => {
-          this.status({
-            fill: "green",
-            shape: "dot",
-            text: "sent: " + msg.payload.text
+        M.post('statuses', body)
+          .then(() => {
+            this.status({
+              fill: 'green',
+              shape: 'dot',
+              text: 'sent: ' + msg.payload.text,
+            });
+          })
+          .catch((err) => {
+            this.status({
+              fill: 'red',
+              shape: 'dot',
+              text: 'Error: ' + err.message,
+            });
           });
-        }).catch(err => {
-          this.status({
-            fill: "red",
-            shape: "dot",
-            text: "Error: " + err.message
-          });
-        });
       }
     });
 
-    this.on("close", function() {
+    this.on('close', function () {
       try {
         this.status({
-          fill: "red",
-          shape: "dot",
-          text: "Stopped"
+          fill: 'red',
+          shape: 'dot',
+          text: 'Stopped',
         });
       } catch (err) {
         console.log(err);
@@ -205,5 +201,5 @@ module.exports = function(RED) {
 
   // Register the node by name. This must be called before overriding any of the
   // Node functions.
-  RED.nodes.registerType("sendMessage", sendMessage);
-}
+  RED.nodes.registerType('sendMessage', sendMessage);
+};

--- a/mastodon/sendMessage.js
+++ b/mastodon/sendMessage.js
@@ -21,6 +21,33 @@ module.exports = function(RED) {
   const fs = require('fs');
   const {Duplex} = require('stream')
 
+  // Helper function to create a file stream from image data
+  function createFileStream(imageData) {
+    if (typeof imageData === 'string') {
+      return fs.createReadStream(imageData);
+    } else if (typeof imageData === 'object' && Buffer.isBuffer(imageData)) {
+      const stream = new Duplex();
+      stream.path = '/tmp/image';
+      stream.push(imageData);
+      stream.push(null);
+      return stream;
+    }
+    return null;
+  }
+
+  // Helper function to upload a single image
+  function uploadImage(M, imageData, description) {
+    const file = createFileStream(imageData);
+    if (!file) {
+      return Promise.reject(new Error('Invalid image data'));
+    }
+    const body = { file };
+    if (description) {
+      body.description = description;
+    }
+    return M.post('media', body).then(resp => resp.data.id);
+  }
+
   function sendMessage(n) {
     RED.nodes.createNode(this, n);
 
@@ -51,43 +78,75 @@ module.exports = function(RED) {
         api_url: this.api_url, // optional, defaults to https://mastodon.social/api/v1/
       });
       if (msg.payload.hasOwnProperty('image')) {
-        var id;
-        var file
-        if (typeof msg.payload.image === 'string') {
-          file = fs.createReadStream(msg.payload.image)
-        } else if (typeof msg.payload.image === 'object' && Buffer.isBuffer(msg.payload.image)) {
-          console.log("image is buffer")
-          file = new Duplex()
-          file.path = '/tmp/image'
-          file.push(msg.payload.image)
-          file.push(null)
-        }
-        const body = {
-          file
-        }
-        if (msg.payload.description) {
-          body.description = msg.payload.description
-        }
-        M.post('media', body).then(resp => {
-          id = resp.data.id;
-          const body = {
-            status: msg.payload.text,
-            visibility: msg.payload.visibility || this.visibility,
-            media_ids: [id]
-          }
-          if (msg.payload.contentWarning) {
-            body.spoiler_text = msg.payload.contentWarning
-          }
-          if (msg.payload.sensitive) {
-            body.sensitive = true
-          }
-          M.post('statuses', body);
-          this.status({
-            fill: "green",
-            shape: "dot",
-            text: "sent: " + msg.payload.text
+        // Check if image is an array
+        if (Array.isArray(msg.payload.image)) {
+          // Handle array of images
+          const uploadPromises = msg.payload.image.map(item => {
+            // Each item should be { image: buffer/filename, description: string }
+            if (typeof item === 'object' && item.image) {
+              return uploadImage(M, item.image, item.description);
+            } else {
+              // Fallback for simple array of buffers/filenames
+              return uploadImage(M, item, null);
+            }
           });
-        });
+
+          Promise.all(uploadPromises).then(media_ids => {
+            const body = {
+              status: msg.payload.text,
+              visibility: msg.payload.visibility || this.visibility,
+              media_ids: media_ids
+            };
+            if (msg.payload.contentWarning) {
+              body.spoiler_text = msg.payload.contentWarning;
+            }
+            if (msg.payload.sensitive) {
+              body.sensitive = true;
+            }
+            M.post('statuses', body);
+            this.status({
+              fill: "green",
+              shape: "dot",
+              text: "sent: " + msg.payload.text
+            });
+          }).catch(err => {
+            this.status({
+              fill: "red",
+              shape: "dot",
+              text: "Error: " + err.message
+            });
+          });
+        } else {
+          // Handle single image (existing behavior)
+          var id;
+          var file = createFileStream(msg.payload.image);
+          const body = {
+            file
+          }
+          if (msg.payload.description) {
+            body.description = msg.payload.description
+          }
+          M.post('media', body).then(resp => {
+            id = resp.data.id;
+            const body = {
+              status: msg.payload.text,
+              visibility: msg.payload.visibility || this.visibility,
+              media_ids: [id]
+            }
+            if (msg.payload.contentWarning) {
+              body.spoiler_text = msg.payload.contentWarning
+            }
+            if (msg.payload.sensitive) {
+              body.sensitive = true
+            }
+            M.post('statuses', body);
+            this.status({
+              fill: "green",
+              shape: "dot",
+              text: "sent: " + msg.payload.text
+            });
+          });
+        }
       } else {
         const body = {
           status: msg.payload.text,


### PR DESCRIPTION
Hi there,

I've started using this project for sending mastodon post, but I wanted to support multiple images. I initially had copilot do the ground work then refactored some of the code myself (just to reduce the repeated code).

I'm using this fork in my own process now and am happy to report it all works as expected (though I did make an executive decision on the structure of the payload for multiple images - specifically including the description feild as part of the elements in the array - which is documented).

I'm using this to automate posting from bluesky to mastodon through a node-red working, using a function to prepare the multiple images from bsky.

Example seen here - [this was the input post on bsky](https://bsky.app/profile/remysharp.com/post/3m6k5j2fxds24) and the resulting [post on mastodon](https://mastodon.social/@remysharp_testing/115617130472841855) (includes all the alt text etc).

For completeness, [this is the original PR which includes the prompt](https://github.com/remy/node-red-contrib-mastodon/pull/1) I used.